### PR TITLE
add flag to dock_from_renv function

### DIFF
--- a/R/dock_from_renv.R
+++ b/R/dock_from_renv.R
@@ -245,7 +245,7 @@ dock_from_renv <- function(
   if (keep_renv_version){
     dock$RUN("R -e 'install.packages(\"remotes\")'")
       install_renv_string <- paste0(
-        "R -e 'remotes::install.version(\"renv\", version = ",
+        "R -e 'remotes::install_version(\"renv\", version = ",
         renv_version,
         ")'"
       )

--- a/R/dock_from_renv.R
+++ b/R/dock_from_renv.R
@@ -22,6 +22,8 @@ available_distros <- c(
 #' @param repos character. The URL(s) of the repositories to use for `options("repos")`.
 #' @param extra_sysreqs character vector. Extra debian system requirements.
 #'    Will be installed with apt-get install.
+#' @param keep_renv_version boolean. If `TRUE` the version of renv in the lockfile
+#'    will be used for the `renv::restore()` command
 #' @importFrom utils getFromNamespace
 #' @return A R6 object of class `Dockerfile`.
 #' @details
@@ -52,7 +54,8 @@ dock_from_renv <- function(
   sysreqs = TRUE,
   repos = c(CRAN = "https://cran.rstudio.com/"),
   expand = FALSE,
-  extra_sysreqs = NULL
+  extra_sysreqs = NULL,
+  keep_renv_version = FALSE
 ) {
   distro <- match.arg(distro, available_distros)
 
@@ -71,6 +74,9 @@ dock_from_renv <- function(
     ),
     AS = AS
   )
+
+  # get renv version
+  renv_version <- lock$data()$Packages$renv$Version
 
   distro_args <- switch(
     distro,
@@ -235,7 +241,19 @@ dock_from_renv <- function(
     )
   )
 
-  dock$RUN("R -e 'install.packages(c(\"renv\",\"remotes\"))'")
+  # check if keep_renv_version is true
+  if (keep_renv_version){
+    dock$RUN("R -e 'install.packages(\"remotes\")'")
+      install_renv_string <- paste0(
+        "R -e 'remotes::install.version(\"renv\", version = ",
+        renv_version,
+        ")'"
+      )
+      dock$RUN(install_renv_string)
+
+  } else {
+    dock$RUN("R -e 'install.packages(c(\"renv\",\"remotes\"))'")
+  }
 
   dock$COPY(basename(lockfile), "renv.lock")
   dock$RUN(r(renv::restore()))

--- a/tests/testthat/test-dock_from_renv.R
+++ b/tests/testthat/test-dock_from_renv.R
@@ -57,7 +57,7 @@ test_that("dock_from_renv works with old renv", {
 })
 
 # dock_from_renv ----
-test_that("dock_from_renv works with keep_renv_version", {
+test_that("dock_from_renv works", {
   # skip_if_not(interactive())
   # Create Dockerfile
 

--- a/tests/testthat/test-dock_from_renv.R
+++ b/tests/testthat/test-dock_from_renv.R
@@ -26,8 +26,38 @@ renv_file <- readLines(file.path(dir_build, "renv.lock"))
 renv_file[grep("Version", renv_file)[1]] <- '    "Version": "4.1.2",'
 writeLines(renv_file, file.path(dir_build, "renv.lock"))
 
+test_that("dock_from_renv works with old renv", {
+  out <- dock_from_renv(
+    lockfile = the_lockfile,
+    distro = "focal",
+    FROM = "rocker/verse",
+    keep_renv_version = TRUE
+  )
+
+  out$write(
+    file.path(
+      dir_build,
+      "Dockerfile"
+    )
+  )
+
+  dock_created <- readLines(
+    file.path(
+      dir_build,
+      "Dockerfile"
+    )
+  )
+
+  test_string <- "remotes::install.version\\(\"renv\", version = 1.0.2\\)"
+  message(test_string)
+  expect_length(
+    grep(test_string , dock_created), 1
+  )
+
+})
+
 # dock_from_renv ----
-test_that("dock_from_renv works", {
+test_that("dock_from_renv works with keep_renv_version", {
   # skip_if_not(interactive())
   # Create Dockerfile
 


### PR DESCRIPTION
adding flag to dock_from_renv function, keep_renv_version to allow the dockerfile to use the same version of renv as specified in the lockfile.  

See [issue 59](https://github.com/ThinkR-open/dockerfiler/issues/59)