### PR TITLE
allow multistage docker

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dockerfiler
 Title: Easy Dockerfile Creation from R
-Version: 0.2.4
+Version: 0.2.4.9000
 Authors@R: c(
     person("Colin", "Fay", , "contact@colinfay.me", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0001-7343-1846")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dockerfiler 0.2.4.9xxx
+
+- allow multistage dockerfile creation
+
 # dockerfiler 0.2.4
 
 - remove native pipe thanks to @HenningLorenzen-ext-bayer, this enable to use of older R versions

--- a/R/add.R
+++ b/R/add.R
@@ -31,19 +31,22 @@ add_add <- function(
   glue("ADD {from} {to}")
 }
 
-add_copy <- function(
-  from,
-  to,
-  force = TRUE
-) {
+add_copy <- function(from,
+                     to,
+                     stage = NULL,
+                     force = TRUE) {
   if (!force) {
-    warn_if_not(
-      normalizePath(from),
-      file.exists,
-      "The file `from` doesn't seem to exists"
-    )
+    warn_if_not(normalizePath(from),
+                file.exists,
+                "The file `from` doesn't seem to exists")
   }
-  glue("COPY {from} {to}")
+
+  if (is.null(stage)) {
+    glue("COPY {from} {to}")
+  } else {
+    glue("COPY --from={stage} {from} {to}")
+
+  }
 }
 
 add_workdir <- function(where) {

--- a/R/dockerfile.R
+++ b/R/dockerfile.R
@@ -39,9 +39,10 @@ self$Dockerfile <- c(self$Dockerfile, add_add(from, to, force))
 #' @param from The source file.
 #' @param to The destination file.
 #' @param force If TRUE, overwrite the destination file.
+#' @param stage Optional. Name of the build stage (e.g., `"builder"`) to copy files from. This corresponds to the `--from=` part in a Dockerfile COPY instruction (e.g., `COPY --from=builder /source /dest`). If `NULL`, the `--from=` argument is omitted.
 #' @return the Dockerfile object, invisibly.
-COPY = function(from, to, force = TRUE) {
-self$Dockerfile <- c(self$Dockerfile, add_copy(from, to, force))
+COPY = function(from, to, stage= NULL , force = TRUE) {
+self$Dockerfile <- c(self$Dockerfile, add_copy(from, to, stage, force))
 },
 #' @description
 #' Add a WORKDIR command.

--- a/R/dockerfile.R
+++ b/R/dockerfile.R
@@ -162,9 +162,10 @@ cat(self$Dockerfile, sep = "\n")
 #' @description
 #' Write the Dockerfile to a file.
 #' @param as The file to write to.
+#' @param append boolean, if TRUE append to file.
 #' @return used for side effect
-write = function(as = "Dockerfile") {
-base::write(self$Dockerfile, file = as)
+write = function(as = "Dockerfile", append = FALSE) {
+base::write(self$Dockerfile, file = as, append = append)
 },
 #' @description
 #' Switch commands.

--- a/man/Dockerfile.Rd
+++ b/man/Dockerfile.Rd
@@ -120,7 +120,7 @@ the Dockerfile object, invisibly.
 \subsection{Method \code{COPY()}}{
 Add a COPY command.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Dockerfile$COPY(from, to, force = TRUE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Dockerfile$COPY(from, to, stage = NULL, force = TRUE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -129,6 +129,8 @@ Add a COPY command.
 \item{\code{from}}{The source file.}
 
 \item{\code{to}}{The destination file.}
+
+\item{\code{stage}}{Optional. Name of the build stage (e.g., \code{"builder"}) to copy files from. This corresponds to the \verb{--from=} part in a Dockerfile COPY instruction (e.g., \code{COPY --from=builder /source /dest}). If \code{NULL}, the \verb{--from=} argument is omitted.}
 
 \item{\code{force}}{If TRUE, overwrite the destination file.}
 }
@@ -459,13 +461,15 @@ used for side effect
 \subsection{Method \code{write()}}{
 Write the Dockerfile to a file.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Dockerfile$write(as = "Dockerfile")}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Dockerfile$write(as = "Dockerfile", append = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{as}}{The file to write to.}
+
+\item{\code{append}}{boolean, if TRUE append to file.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-copy-stage.R
+++ b/tests/testthat/test-copy-stage.R
@@ -1,0 +1,27 @@
+test_that("Dockerfile COPY with build stage works correctly", {
+  # Création des deux étapes du Dockerfile
+  stage_1 <- Dockerfile$new(FROM = "alpine", AS = "builder")
+  stage_1$RUN('echo "coucou depuis le builder" > /coucou')
+
+  stage_2 <- Dockerfile$new(FROM = "ubuntu")
+  stage_2$COPY(from = "/coucou", to = "/truc.txt", force = TRUE, stage = "builder")
+  stage_2$RUN("cat /truc.txt")
+
+  tmpfile <- tempfile(fileext = ".Dockerfile")
+  stage_1$write(as = tmpfile)
+  stage_2$write(as = tmpfile, append = TRUE)
+
+  docker_lines <- readLines(tmpfile)
+
+  expect_length(docker_lines, 5)
+
+  expect_equal(docker_lines[1], "FROM alpine AS builder")
+  expect_equal(docker_lines[2], 'RUN echo "coucou depuis le builder" > /coucou')
+  expect_equal(docker_lines[3], "FROM ubuntu")
+  expect_equal(docker_lines[4], "COPY --from=builder /coucou /truc.txt")
+  expect_equal(docker_lines[5], "RUN cat /truc.txt")
+
+  expect_true(any(grepl("COPY --from=builder", docker_lines)))
+  expect_true(any(grepl("/coucou", docker_lines)))
+  expect_true(any(grepl("/truc.txt", docker_lines)))
+})


### PR DESCRIPTION
fix #83 
this is the main modification :

```
stage_1 <- Dockerfile$new(
  FROM = "alpine",AS ="builder"
)
stage_1$RUN('echo "coucou depuis le builder" > /coucou')

stage_2 <- Dockerfile$new(
  FROM = "ubuntu"
)
stage_2$COPY(from = "/coucou",to = "/truc.txt",force = TRUE, stage ="builder")
stage_2$RUN( "cat /truc.txt")

stage_1$write()
stage_2$write(append = TRUE)

```
output  :


```

FROM alpine AS builder
RUN echo "coucou depuis le builder" > /coucou

FROM ubuntu
COPY --from=builder /coucou /truc.txt
RUN cat /truc.txt
```


I avoided introducing breaking changes — though the temptation was strong to rename the from parameter to FROM (instead of using stage), and to use source and destination instead of from and to. The same goes for the as argument in write(), which could be problematic and would ideally be renamed to path.

The underlying idea is to keep all uppercase parameters aligned with those expected in the Dockerfile, in a consistent and homogeneous way.